### PR TITLE
docs: align encryption env key naming (Story 1.5)

### DIFF
--- a/docs/architecture/code-review-guidelines.md
+++ b/docs/architecture/code-review-guidelines.md
@@ -18,7 +18,7 @@ These guidelines define what reviewers and authors must check before merging cha
 - Sessions/auth guards applied to protected routes.
 - Rate limiting and security headers configured where appropriate.
 - No secrets or tokens logged; sensitive fields redacted.
-- Crypto uses `ENCRYPTION_MASTER_KEY`; secrets only decrypted in-memory.
+- Crypto uses `ENCRYPTION_KEY` (base64 via `packages/config/src/index.ts` helper); secrets only decrypted in-memory.
 
 ### Data & Migrations
 - Prisma schema diffs reviewed; new fields, indexes, and enums documented.

--- a/docs/architecture/code-review-guidelines.md
+++ b/docs/architecture/code-review-guidelines.md
@@ -18,7 +18,7 @@ These guidelines define what reviewers and authors must check before merging cha
 - Sessions/auth guards applied to protected routes.
 - Rate limiting and security headers configured where appropriate.
 - No secrets or tokens logged; sensitive fields redacted.
-- Crypto uses `ENCRYPTION_KEY` (base64 via `packages/config/src/index.ts` helper); secrets only decrypted in-memory.
+- Crypto uses `ENCRYPTION_KEY` (base64 via `packages/config/src/index.ts` helper; see `.env.example` and `docs/architecture/local-development.md#1-environment-setup` for expected format); secrets only decrypted in-memory.
 
 ### Data & Migrations
 - Prisma schema diffs reviewed; new fields, indexes, and enums documented.

--- a/docs/architecture/ops-runbook.md
+++ b/docs/architecture/ops-runbook.md
@@ -58,14 +58,14 @@ curl -sf http://localhost:3001/healthz
 - For point-in-time recovery (PITR), configure WAL archiving and a backup tool; otherwise use logical dumps.
 
 ## Secrets Rotation
-1. Generate new `SESSION_SECRET` and/or `ENCRYPTION_MASTER_KEY` (base64) securely
+1. Generate new `SESSION_SECRET` and/or `ENCRYPTION_KEY` securely. Keep the key base64-encoded per the shared config helper (`packages/config/src/index.ts`) and the guidance in `.env.example` and `docs/architecture/local-development.md#1-environment-setup`.
 2. Update environment for API/worker containers (Docker/OS secrets)
 3. Restart services; verify health and auth flows
 4. For master key rotation, plan re-encryption strategy if needed
 
 ## Troubleshooting
 - `GET /healthz` returns 503
-  - Check DB connectivity, `ENCRYPTION_MASTER_KEY`, and env validation failures (API logs)
+  - Check DB connectivity, `ENCRYPTION_KEY`, and env validation failures (API logs)
 - OAuth callback errors
   - Verify redirect URIs and tenant configuration; check provider logs
 - Worker not claiming jobs

--- a/docs/prd/epic-2-connector-configuration-validation.md
+++ b/docs/prd/epic-2-connector-configuration-validation.md
@@ -65,7 +65,7 @@ Acceptance Criteria:
 
 ### Story Draft Validation
 - Quick Summary: READY (clarity 9/10). Ensure key management and logging redaction requirements are explicit in acceptance.
-- Technical Guidance: PASS — Use `ENCRYPTION_MASTER_KEY` (base64) from env; prefer libsodium sealed box or Node crypto with AEAD (AES‑256‑GCM). Centralize crypto in `packages/config` and consume via helpers; audit access events.
+- Technical Guidance: PASS — Use `ENCRYPTION_KEY` (base64 via the shared helper in `packages/config/src/index.ts`) from env; prefer libsodium sealed box or Node crypto with AEAD (AES‑256‑GCM). Centralize crypto in `packages/config` and consume via helpers; audit access events.
 - References: `docs/architecture/security.md#secrets-management` and `.env.example` keys; log redaction guidance under Security.
 - Testing Guidance: Unit: encrypt/decrypt round‑trip; tamper ciphertext → fail; missing/short key → startup error. Integration: ensure secrets never appear in logs; audit entries on access.
 

--- a/docs/prd/provider-credentials-setup.md
+++ b/docs/prd/provider-credentials-setup.md
@@ -4,7 +4,7 @@ This guide helps you create OAuth apps for Google Calendar and Microsoft Graph a
 
 ## Security & Ownership
 - Never commit real secrets to Git. Use `.env.local` for development, Docker/OS secrets for production.
-- SynCal encrypts connector secrets at rest using a master key from `ENCRYPTION_MASTER_KEY`.
+- SynCal encrypts connector secrets at rest using the base64-encoded `ENCRYPTION_KEY` provided via the shared config helper (`packages/config/src/index.ts`).
 - Users provision provider apps and secrets; SynCal reads them from env only.
 
 ## Who Does What
@@ -90,7 +90,7 @@ API_BASE_URL=http://localhost:3001
 
 # Session & crypto
 SESSION_SECRET=change-me-session-secret
-ENCRYPTION_MASTER_KEY=base64:CHANGE_ME_32_BYTES
+ENCRYPTION_KEY=base64:CHANGE_ME_32_BYTES
 
 # Google
 GOOGLE_CLIENT_ID=
@@ -106,6 +106,8 @@ MS_REDIRECT_URI=http://localhost:3001/auth/microsoft/callback
 MS_OAUTH_SCOPES="openid email profile offline_access Calendars.ReadWrite"
 ```
 
+`ENCRYPTION_KEY` must stay base64-encoded so the shared config helper (`packages/config/src/index.ts`) can load it. Use the generation guidance in `.env.example` and `docs/architecture/local-development.md#1-environment-setup` when provisioning or rotating the key.
+
 ---
 
 ## Verification Checklist
@@ -118,7 +120,7 @@ MS_OAUTH_SCOPES="openid email profile offline_access Calendars.ReadWrite"
 
 ## Notes on Other Connectors
 - HTML/ICS: No credentials needed; URLs and optional headers are configured in-app.
-- IMAP: Credentials entered in-app; stored encrypted using `ENCRYPTION_MASTER_KEY`.
+- IMAP: Credentials entered in-app; stored encrypted using `ENCRYPTION_KEY`.
 
 ## Security Reminders
 - Do not commit `.env*` files. This repository’s `.gitignore` already excludes them.

--- a/docs/prd/roles-and-responsibilities.md
+++ b/docs/prd/roles-and-responsibilities.md
@@ -21,7 +21,7 @@ This document clarifies which tasks belong to humans (operators/owners) and whic
 ### Developer Agent(s)
 - Implement portal, API, and worker per PRD/architecture.
 - Define Prisma schema and migrations; enforce env schema validation at startup.
-- Implement encryption using `ENCRYPTION_MASTER_KEY`; redact logs; audit secret access.
+- Implement encryption using `ENCRYPTION_KEY` (base64, wired through `packages/config/src/index.ts`); redact logs; audit secret access.
 - Implement OAuth callbacks, token storage (encrypted), connector validation jobs, and fallback ordering.
 - Compose stack configuration (`infra/docker-compose.yml`) and CI workflows (`.github/workflows/*`).
 - Frontend UX: navigation, wizards, accessibility (WCAG AA), performance strategies.
@@ -30,7 +30,7 @@ This document clarifies which tasks belong to humans (operators/owners) and whic
 
 ## Secrets Ownership
 - `SESSION_SECRET` — User/Operator
-- `ENCRYPTION_MASTER_KEY` — User/Operator
+- `ENCRYPTION_KEY` (base64 per `.env.example` and local dev guide) — User/Operator
 - `DATABASE_URL` — User/Operator (Dev provides format requirements)
 - `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI`, `GOOGLE_OAUTH_SCOPES` — User/Operator
 - `MS_CLIENT_ID`, `MS_CLIENT_SECRET`, `MS_TENANT_ID`, `MS_REDIRECT_URI`, `MS_OAUTH_SCOPES` — User/Operator

--- a/docs/qa/gates/1.5-env-key-doc-alignment.yml
+++ b/docs/qa/gates/1.5-env-key-doc-alignment.yml
@@ -1,0 +1,38 @@
+schema: 1
+story: '1.5'
+story_title: 'Env Key Doc Alignment'
+gate: PASS
+status_reason: 'Docs now reference ENCRYPTION_KEY with base64 helper guidance and mirror helper links; no stray master key references remain.'
+reviewer: 'Quinn (Test Architect)'
+updated: '2025-09-22T10:00:39Z'
+
+top_issues: []
+waiver: { active: false }
+
+quality_score: 100
+expires: '2025-10-06T00:00:00Z'
+
+evidence:
+  tests_reviewed: 2
+  risks_identified: 0
+  trace:
+    ac_covered: [1, 2, 3]
+    ac_gaps: []
+
+nfr_validation:
+  security:
+    status: PASS
+    notes: 'Key naming and rotation docs align with security helper implementation.'
+  performance:
+    status: PASS
+    notes: 'Documentation-only change; no runtime impact.'
+  reliability:
+    status: PASS
+    notes: 'Runbook guidance updated to prevent misconfiguration during rotations.'
+  maintainability:
+    status: PASS
+    notes: 'Consistent naming reduces confusion; follow-up suggestion noted for link parity.'
+
+recommendations:
+  immediate: []
+  future: []

--- a/docs/stories/1.5.env-key-doc-alignment.md
+++ b/docs/stories/1.5.env-key-doc-alignment.md
@@ -1,5 +1,5 @@
 # Status
-Ready for Dev
+Ready for Review
 
 # Story
 **As a** self-hosting administrator reviewing SynCal docs,
@@ -19,18 +19,18 @@ This work supports Epic 1 – Platform Foundation & Secure Portal by keeping sec
 3. A final repository-wide search confirms no stray `ENCRYPTION_MASTER_KEY` usages remain (excluding change logs/history where appropriate).
 
 # Tasks / Subtasks
-- [ ] Update architecture docs (AC 1, 2)
-  - [ ] Revise `docs/architecture/code-review-guidelines.md#security` to reference `ENCRYPTION_KEY` in security checks and cite the base64 expectation from the shared config helpers.
-  - [ ] Adjust `docs/architecture/ops-runbook.md#secrets-rotation` secrets rotation/troubleshooting steps to match the new env name and validation behavior, referencing `.env.example` for base64 guidance.
+- [x] Update architecture docs (AC 1, 2)
+  - [x] Revise `docs/architecture/code-review-guidelines.md#security` to reference `ENCRYPTION_KEY` in security checks and cite the base64 expectation from the shared config helpers.
+  - [x] Adjust `docs/architecture/ops-runbook.md#secrets-rotation` secrets rotation/troubleshooting steps to match the new env name and validation behavior, referencing `.env.example` for base64 guidance.
 
-- [ ] Update PRD documentation (AC 1, 2)
-  - [ ] Refresh `docs/prd/roles-and-responsibilities.md#secrets-ownership` so ownership tables and responsibilities cite `ENCRYPTION_KEY` and point back to the central config helper docs.
-  - [ ] Align `docs/prd/provider-credentials-setup.md#example-environment-keys` guidance and snippets (env blocks, connector notes) with `ENCRYPTION_KEY`, including explicit base64 notes sourced from `.env.example` and the local development guide.
-  - [ ] Update `docs/prd/epic-2-connector-configuration-validation.md#story-24-connector-encryption-secret-management` technical guidance to reference the correct key name, reiterating the base64 requirement and helper alignment.
+- [x] Update PRD documentation (AC 1, 2)
+  - [x] Refresh `docs/prd/roles-and-responsibilities.md#secrets-ownership` so ownership tables and responsibilities cite `ENCRYPTION_KEY` and point back to the central config helper docs.
+  - [x] Align `docs/prd/provider-credentials-setup.md#example-environment-keys` guidance and snippets (env blocks, connector notes) with `ENCRYPTION_KEY`, including explicit base64 notes sourced from `.env.example` and the local development guide.
+  - [x] Update `docs/prd/epic-2-connector-configuration-validation.md#story-24-connector-encryption-secret-management` technical guidance to reference the correct key name, reiterating the base64 requirement and helper alignment.
 
-- [ ] Consistency validation (AC 3)
-  - [ ] Run `rg "ENCRYPTION_MASTER_KEY"` (or equivalent) to ensure no lingering references remain outside approved historical sections.
-  - [ ] Note results in Completion Notes, capturing the command used.
+- [x] Consistency validation (AC 3)
+  - [x] Run `rg "ENCRYPTION_MASTER_KEY"` (or equivalent) to ensure no lingering references remain outside approved historical sections.
+  - [x] Note results in Completion Notes, capturing the command used.
 
 # Dev Notes
 - Existing configuration helpers (`packages/config`) and `.env.example` already use `ENCRYPTION_KEY`; this story only updates documentation artifacts.
@@ -49,11 +49,18 @@ This work supports Epic 1 – Platform Foundation & Secure Portal by keeping sec
 
 # Dev Agent Record
 ## Agent Model Used
-
+GPT-5 (Codex)
 ## Debug Log References
-
+- n/a
 ## Completion Notes List
-
+- Updated architecture and PRD docs to reference `ENCRYPTION_KEY` and cite the shared config helper plus `.env.example` / local dev guidance for base64 handling.
+- `npm run lint` → `lint pipeline not yet configured` (expected placeholder output).
+- `rg "ENCRYPTION_MASTER_KEY"` now only reports occurrences inside story documentation (`docs/stories/...`).
 ## File List
-
+- docs/architecture/code-review-guidelines.md
+- docs/architecture/ops-runbook.md
+- docs/prd/roles-and-responsibilities.md
+- docs/prd/provider-credentials-setup.md
+- docs/prd/epic-2-connector-configuration-validation.md
+- docs/stories/1.5.env-key-doc-alignment.md
 # QA Results

--- a/docs/stories/1.5.env-key-doc-alignment.md
+++ b/docs/stories/1.5.env-key-doc-alignment.md
@@ -2,9 +2,9 @@
 Draft
 
 # Story
-As a self-hosting administrator reviewing SynCal docs,
-I want all references to the encryption secret to use the same `ENCRYPTION_KEY` name,
-so that setup, security reviews, and runbooks stay consistent with the implemented configuration helpers.
+**As a** self-hosting administrator reviewing SynCal docs,
+**I want** all references to the encryption secret to use the same `ENCRYPTION_KEY` name,
+**so that** setup, security reviews, and runbooks stay consistent with the implemented configuration helpers.
 
 # Acceptance Criteria
 1. Every repo document referencing `ENCRYPTION_MASTER_KEY` is updated (or clarified) to `ENCRYPTION_KEY`, including:
@@ -13,18 +13,18 @@ so that setup, security reviews, and runbooks stay consistent with the implement
    - `docs/prd/roles-and-responsibilities.md`
    - `docs/prd/provider-credentials-setup.md`
    - `docs/prd/epic-2-connector-configuration-validation.md`
-2. Updated docs explicitly note the base64 requirement and tie back to the shared config helper expectations.
+2. Updated docs explicitly note the base64 requirement and tie back to the shared config helper expectations (`packages/config/src/index.ts`, `.env.example`, `docs/architecture/local-development.md`).
 3. A final repository-wide search confirms no stray `ENCRYPTION_MASTER_KEY` usages remain (excluding change logs/history where appropriate).
 
 # Tasks / Subtasks
 - [ ] Update architecture docs (AC 1, 2)
-  - [ ] Revise `docs/architecture/code-review-guidelines.md` to reference `ENCRYPTION_KEY` in security checks.
-  - [ ] Adjust `docs/architecture/ops-runbook.md` secrets rotation/troubleshooting steps to match the new env name and validation behavior.
+  - [ ] Revise `docs/architecture/code-review-guidelines.md` to reference `ENCRYPTION_KEY` in security checks and cite the base64 expectation from the shared config helpers.
+  - [ ] Adjust `docs/architecture/ops-runbook.md` secrets rotation/troubleshooting steps to match the new env name and validation behavior, referencing `.env.example` for base64 guidance.
 
 - [ ] Update PRD documentation (AC 1, 2)
-  - [ ] Refresh `docs/prd/roles-and-responsibilities.md` so ownership tables and responsibilities cite `ENCRYPTION_KEY`.
-  - [ ] Align `docs/prd/provider-credentials-setup.md` guidance and snippets (env blocks, connector notes) with `ENCRYPTION_KEY`.
-  - [ ] Update `docs/prd/epic-2-connector-configuration-validation.md` technical guidance to reference the correct key name and base64 requirement.
+  - [ ] Refresh `docs/prd/roles-and-responsibilities.md` so ownership tables and responsibilities cite `ENCRYPTION_KEY` and point back to the central config helper docs.
+  - [ ] Align `docs/prd/provider-credentials-setup.md` guidance and snippets (env blocks, connector notes) with `ENCRYPTION_KEY`, including explicit base64 notes sourced from `.env.example` and the local development guide.
+  - [ ] Update `docs/prd/epic-2-connector-configuration-validation.md` technical guidance to reference the correct key name, reiterating the base64 requirement and helper alignment.
 
 - [ ] Consistency validation (AC 3)
   - [ ] Run `rg "ENCRYPTION_MASTER_KEY"` (or equivalent) to ensure no lingering references remain outside approved historical sections.
@@ -55,4 +55,3 @@ so that setup, security reviews, and runbooks stay consistent with the implement
 ## File List
 
 # QA Results
-

--- a/docs/stories/1.5.env-key-doc-alignment.md
+++ b/docs/stories/1.5.env-key-doc-alignment.md
@@ -1,30 +1,32 @@
 # Status
-Draft
+Ready for Dev
 
 # Story
 **As a** self-hosting administrator reviewing SynCal docs,
 **I want** all references to the encryption secret to use the same `ENCRYPTION_KEY` name,
 **so that** setup, security reviews, and runbooks stay consistent with the implemented configuration helpers.
 
+This work supports Epic 1 – Platform Foundation & Secure Portal by keeping security documentation aligned with the deployed helpers.
+
 # Acceptance Criteria
 1. Every repo document referencing `ENCRYPTION_MASTER_KEY` is updated (or clarified) to `ENCRYPTION_KEY`, including:
-   - `docs/architecture/code-review-guidelines.md`
-   - `docs/architecture/ops-runbook.md`
-   - `docs/prd/roles-and-responsibilities.md`
-   - `docs/prd/provider-credentials-setup.md`
-   - `docs/prd/epic-2-connector-configuration-validation.md`
-2. Updated docs explicitly note the base64 requirement and tie back to the shared config helper expectations (`packages/config/src/index.ts`, `.env.example`, `docs/architecture/local-development.md`).
+   - `docs/architecture/code-review-guidelines.md#security`
+   - `docs/architecture/ops-runbook.md#secrets-rotation`
+   - `docs/prd/roles-and-responsibilities.md#secrets-ownership`
+   - `docs/prd/provider-credentials-setup.md#example-environment-keys`
+   - `docs/prd/epic-2-connector-configuration-validation.md#story-24-connector-encryption-secret-management`
+2. Updated docs explicitly note the base64 requirement and tie back to the shared config helper expectations (`packages/config/src/index.ts`, `.env.example`, `docs/architecture/local-development.md#1-environment-setup`).
 3. A final repository-wide search confirms no stray `ENCRYPTION_MASTER_KEY` usages remain (excluding change logs/history where appropriate).
 
 # Tasks / Subtasks
 - [ ] Update architecture docs (AC 1, 2)
-  - [ ] Revise `docs/architecture/code-review-guidelines.md` to reference `ENCRYPTION_KEY` in security checks and cite the base64 expectation from the shared config helpers.
-  - [ ] Adjust `docs/architecture/ops-runbook.md` secrets rotation/troubleshooting steps to match the new env name and validation behavior, referencing `.env.example` for base64 guidance.
+  - [ ] Revise `docs/architecture/code-review-guidelines.md#security` to reference `ENCRYPTION_KEY` in security checks and cite the base64 expectation from the shared config helpers.
+  - [ ] Adjust `docs/architecture/ops-runbook.md#secrets-rotation` secrets rotation/troubleshooting steps to match the new env name and validation behavior, referencing `.env.example` for base64 guidance.
 
 - [ ] Update PRD documentation (AC 1, 2)
-  - [ ] Refresh `docs/prd/roles-and-responsibilities.md` so ownership tables and responsibilities cite `ENCRYPTION_KEY` and point back to the central config helper docs.
-  - [ ] Align `docs/prd/provider-credentials-setup.md` guidance and snippets (env blocks, connector notes) with `ENCRYPTION_KEY`, including explicit base64 notes sourced from `.env.example` and the local development guide.
-  - [ ] Update `docs/prd/epic-2-connector-configuration-validation.md` technical guidance to reference the correct key name, reiterating the base64 requirement and helper alignment.
+  - [ ] Refresh `docs/prd/roles-and-responsibilities.md#secrets-ownership` so ownership tables and responsibilities cite `ENCRYPTION_KEY` and point back to the central config helper docs.
+  - [ ] Align `docs/prd/provider-credentials-setup.md#example-environment-keys` guidance and snippets (env blocks, connector notes) with `ENCRYPTION_KEY`, including explicit base64 notes sourced from `.env.example` and the local development guide.
+  - [ ] Update `docs/prd/epic-2-connector-configuration-validation.md#story-24-connector-encryption-secret-management` technical guidance to reference the correct key name, reiterating the base64 requirement and helper alignment.
 
 - [ ] Consistency validation (AC 3)
   - [ ] Run `rg "ENCRYPTION_MASTER_KEY"` (or equivalent) to ensure no lingering references remain outside approved historical sections.
@@ -37,8 +39,8 @@ Draft
 - Coordinate with QA to re-verify `docs/stories/1.1.bootstrap-project-docker-stack.md` QA notes once sweep completes.
 
 ## Testing
-- Documentation lint/format (if applicable).
-- Manual validation: repository search showing zero `ENCRYPTION_MASTER_KEY` hits in active docs.
+- Run `npm run lint` to catch documentation formatting regressions (lint pipeline placeholder still required) [Source: docs/architecture/test-strategy-and-standards.md#continuous-testing]
+- Manual validation: `rg "ENCRYPTION_MASTER_KEY"` returns no stray hits outside approved history sections [Source: docs/architecture/ops-runbook.md#secrets-rotation]
 
 # Change Log
 | Date       | Version | Description               | Author       |

--- a/docs/stories/1.5.env-key-doc-alignment.md
+++ b/docs/stories/1.5.env-key-doc-alignment.md
@@ -1,5 +1,5 @@
 # Status
-Ready for Review
+Done
 
 # Story
 **As a** self-hosting administrator reviewing SynCal docs,
@@ -64,3 +64,24 @@ GPT-5 (Codex)
 - docs/prd/epic-2-connector-configuration-validation.md
 - docs/stories/1.5.env-key-doc-alignment.md
 # QA Results
+
+### Review Date: 2025-09-22
+### Reviewed By: Quinn (Test Architect)
+
+### Requirements Traceability
+- AC1 **PASS** – All named docs now reference `ENCRYPTION_KEY`; verified snippets in `docs/architecture/code-review-guidelines.md#security`, `docs/architecture/ops-runbook.md#secrets-rotation`, PRD sections, and Epic 2 guidance.
+- AC2 **PASS** – Each update reiterates the base64 requirement, links back to the shared config helper, and now consistently references `.env.example` plus the local dev guide.
+- AC3 **PASS** – `rg "ENCRYPTION_MASTER_KEY"` only finds references inside story metadata after the sweep.
+
+### Tests & Validation
+- `npm run lint` → outputs placeholder `lint pipeline not yet configured` (expected per project standards).
+- Manual: `rg "ENCRYPTION_MASTER_KEY"` → no hits outside story documentation sections.
+
+### NFR Review
+- Security: PASS – Documentation aligns with runtime helper expectations and reinforces secure key handling/rotation.
+- Performance: PASS – No runtime impact; docs clarify configuration only.
+- Reliability: PASS – Rotation/troubleshooting guidance now reflects actual key name, reducing operator error risk.
+- Maintainability: PASS – Naming consistency restored; minor follow-up noted above for link parity in review checklist.
+
+### Recommendation
+- Ready for Done – checklist now mirrors `.env.example` and local dev references.


### PR DESCRIPTION
### Linked Issue(s)
Closes #10

### Summary
Story 1.5 standardizes all documentation references from `ENCRYPTION_MASTER_KEY` to `ENCRYPTION_KEY`, aligning security, operational, and PRD docs with the implemented configuration helpers (`packages/config`) and `.env.example` naming. Adds/clarifies the base64 requirement and cross-links local development setup to reduce onboarding and rotation errors.

### Changes
- Updated `docs/architecture/code-review-guidelines.md#security` to use `ENCRYPTION_KEY` and cite base64 expectation.
- Adjusted `docs/architecture/ops-runbook.md#secrets-rotation` rotation & troubleshooting instructions with new key name and helper reference.
- Revised PRD docs (`roles-and-responsibilities`, `provider-credentials-setup`, `epic-2-connector-configuration-validation` Story 24 section) to reflect new naming and base64 guidance.
- Added cross-references to `.env.example` and `local-development.md` where relevant.
- Updated Story 1.5 record and QA gate artifacts.

### Breaking Changes
None – documentation only.

### Database / Migrations
None.

### Security Considerations
- Eliminates inconsistent naming that could lead to misconfigured encryption secrets.
- Reinforces base64 encoding requirement reducing operator error surface.

### Observability / Logging / Metrics
No changes.

### Privacy / Data Handling
No runtime impact; improves clarity of secret handling steps.

### Performance
No impact.

### Testing
- Manual grep: `rg "ENCRYPTION_MASTER_KEY"` now yields hits only inside story metadata/history contexts (validated per AC3).
- `npm run lint` executed (lint pipeline placeholder – no doc formatting regressions observed).

### Documentation Updates
This PR itself is a doc alignment sweep; Story 1.5 updated with completion notes and file list.

### Additional Notes
Follow-up (optional): Add a small configuration validator script referenced in ops-runbook to programmatically confirm base64 length and entropy.

---
Reviewer Checklist:
- [ ] All prior references updated
- [ ] Base64 requirement explicitly documented everywhere key appears
- [ ] No stray `ENCRYPTION_MASTER_KEY` usages (outside historical/story contexts)
- [ ] Story 1.5 gate indicates PASS
